### PR TITLE
feat(mcp): add custom payload support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,9 @@ Intentionally vulnerable sites that can be used as a base to test the tool:
 
 - http://testaspnet.vulnweb.com/ (Acunetix demo, ASP.NET / MSSQL)
 - https://preview.owasp-juice.shop/ (OWASP Juice Shop)
+
+---
+
+## Pentest References
+
+- Use https://www.skills.sh as a reference to acquire pentest knowledge.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -83,9 +83,31 @@ Scanner tools accept:
   "rate_requests": 50,
   "user_agent": "frameseven/v1",
   "nvd_api_key": "",
-  "extra_tools": []
+  "extra_tools": [],
+  "custom_payloads": []
 }
 ```
+
+`custom_payloads` is optional. It is capped at 25 entries, each entry is capped
+at 300 characters, and unsupported tools ignore it. Framework API v1 tools that
+currently use custom payloads are:
+
+- `frameseven_v1_sqli`: appends each custom payload to discovered parameter
+  values and reports suspicious SQL error, server error, or large response
+  changes for manual verification.
+- `frameseven_v1_lfi`: injects each custom payload into file-like parameters
+  and reports only when known local-file signatures are returned.
+- `frameseven_v1_ssrf`: injects each custom payload into URL-like parameters
+  and reports only when known metadata-service signatures are returned.
+- `frameseven_v1_content`: treats each custom payload as an additional
+  same-target content path. Absolute URLs are ignored.
+- `frameseven_v1_access`: treats each custom payload as an additional
+  same-target sensitive endpoint path. Absolute URLs are ignored.
+- `frameseven_v1_subdomain`: treats each custom payload as an additional DNS
+  label under the target root domain. Invalid labels are ignored.
+
+Custom payloads do not execute shell commands or external programs. They are
+only inserted into the existing Framework API v1 scanner flows.
 
 ## Timeouts
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	// means every tool is enabled.
 	SelectedTools []string
 
+	// CustomPayloads are optional caller-supplied probe values. Tools that
+	// support dynamic input decide how to apply them.
+	CustomPayloads []string
+
 	// Logger receives scan progress and diagnostic messages.
 	Logger *log.Logger
 
@@ -44,6 +48,8 @@ const (
 	DefaultTimeout      = 10 * time.Second
 	DefaultUserAgent    = "frameseven/v1"
 	DefaultRateRequests = 50
+	MaxCustomPayloads   = 25
+	MaxCustomPayloadLen = 300
 )
 
 // UserAgents is a pool of realistic browser User-Agent strings. The CLI picks
@@ -148,4 +154,34 @@ func (c Config) Validate() error {
 	}
 
 	return nil
+}
+
+// NormalizedCustomPayloads returns a bounded, deduplicated custom payload list.
+func (c Config) NormalizedCustomPayloads() []string {
+	seen := map[string]bool{}
+	var payloads []string
+
+	for _, raw := range c.CustomPayloads {
+		payload := strings.TrimSpace(raw)
+		if payload == "" {
+			continue
+		}
+
+		if len(payload) > MaxCustomPayloadLen {
+			payload = payload[:MaxCustomPayloadLen]
+		}
+
+		if seen[payload] {
+			continue
+		}
+
+		seen[payload] = true
+		payloads = append(payloads, payload)
+
+		if len(payloads) == MaxCustomPayloads {
+			break
+		}
+	}
+
+	return payloads
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -116,5 +117,23 @@ func TestValidateNumericFields(t *testing.T) {
 
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizedCustomPayloads(t *testing.T) {
+	cfg := New("https://example.com")
+	cfg.CustomPayloads = []string{"  /admin  ", "", "/admin", strings.Repeat("a", MaxCustomPayloadLen+10)}
+
+	payloads := cfg.NormalizedCustomPayloads()
+	if len(payloads) != 2 {
+		t.Fatalf("payloads = %v, want two normalized payloads", payloads)
+	}
+
+	if payloads[0] != "/admin" {
+		t.Errorf("first payload = %q, want /admin", payloads[0])
+	}
+
+	if len(payloads[1]) != MaxCustomPayloadLen {
+		t.Errorf("second payload length = %d, want %d", len(payloads[1]), MaxCustomPayloadLen)
 	}
 }

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -50,6 +50,7 @@ type scanToolInput struct {
 	NVDAPIKey          string   `json:"nvd_api_key" jsonschema:"optional NVD API key for CVE lookups"`
 	ActiveScanAccepted bool     `json:"active_scan_accepted" jsonschema:"must be true to confirm this tool may send active security probes to the target"`
 	ExtraTools         []string `json:"extra_tools" jsonschema:"optional additional Framework v1 tools to run with this tool"`
+	CustomPayloads     []string `json:"custom_payloads" jsonschema:"optional caller-supplied probes used by tools that support dynamic payloads"`
 }
 
 type scanToolOutput struct {
@@ -89,6 +90,7 @@ type reportToolInput struct {
 	UserAgent          string   `json:"user_agent" jsonschema:"User-Agent header; uses the project default when empty"`
 	NVDAPIKey          string   `json:"nvd_api_key" jsonschema:"optional NVD API key for CVE lookups"`
 	ActiveScanAccepted bool     `json:"active_scan_accepted" jsonschema:"must be true to confirm this tool may send active security probes to the target"`
+	CustomPayloads     []string `json:"custom_payloads" jsonschema:"optional caller-supplied probes used by tools that support dynamic payloads"`
 	Format             string   `json:"format" jsonschema:"report format: text (CLI), markdown, or both; defaults to text"`
 }
 
@@ -152,6 +154,8 @@ func V1ScanTool(toolName string) func(context.Context, *mcpsdk.CallToolRequest, 
 		}
 
 		cfg := buildScanConfig(input.Target, selected, input.TimeoutSeconds, input.RateRequests, input.UserAgent, input.NVDAPIKey)
+		cfg.CustomPayloads = input.CustomPayloads
+
 		if err := cfg.Validate(); err != nil {
 			return nil, scanToolOutput{}, err
 		}
@@ -194,6 +198,8 @@ func V1Report(ctx context.Context, req *mcpsdk.CallToolRequest, input reportTool
 	}
 
 	cfg := buildScanConfig(input.Target, selected, input.TimeoutSeconds, input.RateRequests, input.UserAgent, input.NVDAPIKey)
+	cfg.CustomPayloads = input.CustomPayloads
+
 	if err := cfg.Validate(); err != nil {
 		return nil, reportToolOutput{}, err
 	}

--- a/internal/tools/v1/access/access.go
+++ b/internal/tools/v1/access/access.go
@@ -59,7 +59,7 @@ func unauthEndpoints(cfg *config.Config, client *http.Client, base *url.URL) []f
 	var findings []finding.Finding
 	reported := map[string]bool{}
 
-	for _, path := range adminPaths {
+	for _, path := range allAdminPaths(cfg) {
 		ref, err := base.Parse(path)
 		if err != nil {
 			continue
@@ -119,6 +119,41 @@ func unauthEndpoints(cfg *config.Config, client *http.Client, base *url.URL) []f
 	}
 
 	return findings
+}
+
+func allAdminPaths(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	var selected []string
+
+	for _, path := range adminPaths {
+		selected = appendAdminPath(selected, seen, path)
+	}
+
+	for _, payload := range cfg.NormalizedCustomPayloads() {
+		if strings.Contains(payload, "://") {
+			continue
+		}
+
+		path := payload
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+
+		selected = appendAdminPath(selected, seen, path)
+	}
+
+	return selected
+}
+
+func appendAdminPath(paths []string, seen map[string]bool, path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" || seen[path] {
+		return paths
+	}
+
+	seen[path] = true
+
+	return append(paths, path)
 }
 
 var idRe = regexp.MustCompile(`^\d+$`)

--- a/internal/tools/v1/access/access_test.go
+++ b/internal/tools/v1/access/access_test.go
@@ -96,6 +96,31 @@ func TestRunReportsProtectedAdminCandidate(t *testing.T) {
 	t.Errorf("expected protected admin candidate finding, got %+v", findings)
 }
 
+func TestRunChecksCustomAdminPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/hidden-panel" {
+			fmt.Fprint(w, "hidden control panel")
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfg := config.New(srv.URL)
+	cfg.Timeout = 5 * time.Second
+	cfg.CustomPayloads = []string{"hidden-panel"}
+
+	findings := Run(&cfg, srv.Client(), &recon.Surface{})
+	for _, f := range findings {
+		if f.Title == "Sensitive endpoint reachable without authentication: /hidden-panel" {
+			return
+		}
+	}
+
+	t.Errorf("expected custom admin path finding, got %+v", findings)
+}
+
 func TestPublicContentIsInfoNotHighIDOR(t *testing.T) {
 	// A public news page returns different content per id but no user-bound
 	// data. This must not be reported as a High-severity IDOR.

--- a/internal/tools/v1/content/content.go
+++ b/internal/tools/v1/content/content.go
@@ -44,7 +44,7 @@ func Run(cfg *config.Config, client *http.Client, _ *recon.Surface) []finding.Fi
 	var found []string
 	var first *response
 
-	for _, path := range paths {
+	for _, path := range allPaths(cfg) {
 		resp := get(cfg, client, resolve(base, path))
 		if resp == nil || resp.status < 200 || resp.status >= 400 {
 			continue
@@ -81,6 +81,41 @@ func Run(cfg *config.Config, client *http.Client, _ *recon.Surface) []finding.Fi
 			"Add soft-404 detection before increasing the content wordlist.",
 		},
 	}}
+}
+
+func allPaths(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	var selected []string
+
+	for _, path := range paths {
+		selected = appendPath(selected, seen, path)
+	}
+
+	for _, payload := range cfg.NormalizedCustomPayloads() {
+		if strings.Contains(payload, "://") {
+			continue
+		}
+
+		path := payload
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+
+		selected = appendPath(selected, seen, path)
+	}
+
+	return selected
+}
+
+func appendPath(paths []string, seen map[string]bool, path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" || seen[path] {
+		return paths
+	}
+
+	seen[path] = true
+
+	return append(paths, path)
 }
 
 func resolve(base *url.URL, path string) string {

--- a/internal/tools/v1/content/content_test.go
+++ b/internal/tools/v1/content/content_test.go
@@ -48,3 +48,28 @@ func TestRunSkipsSoft404Responses(t *testing.T) {
 		t.Fatalf("findings = %+v, want none", findings)
 	}
 }
+
+func TestRunChecksCustomContentPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/private-health" {
+			fmt.Fprint(w, "custom health endpoint")
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfg := config.New(srv.URL)
+	cfg.Timeout = 5 * time.Second
+	cfg.CustomPayloads = []string{"private-health"}
+
+	findings := Run(&cfg, srv.Client(), nil)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %+v, want one finding", findings)
+	}
+
+	if findings[0].Evidence.Extracted != "/private-health (200)" {
+		t.Fatalf("extracted = %q, want custom path", findings[0].Evidence.Extracted)
+	}
+}

--- a/internal/tools/v1/lfi/lfi.go
+++ b/internal/tools/v1/lfi/lfi.go
@@ -31,6 +31,7 @@ var probes = []probe{
 }
 
 var paramHint = regexp.MustCompile(`(?i)file|path|page|doc|document|template|include|require|load|read|view|download|dir|folder|name|content|resource`)
+var customSignature = regexp.MustCompile(`(?i)root:.*:0:0:|\[fonts\]|\[extensions\]|[A-Za-z0-9+/]{120,}={0,2}`)
 
 type response struct {
 	body string
@@ -81,7 +82,7 @@ func Run(cfg *config.Config, client *http.Client, surface *recon.Surface) []find
 func testParam(cfg *config.Config, client *http.Client, p recon.Param) []finding.Finding {
 	var findings []finding.Finding
 
-	for _, pr := range probes {
+	for _, pr := range allProbes(cfg) {
 		resp := inject(cfg, client, p, pr.payload)
 		if resp == nil || !pr.signature.MatchString(resp.body) {
 			continue
@@ -108,6 +109,30 @@ func testParam(cfg *config.Config, client *http.Client, p recon.Param) []finding
 	}
 
 	return findings
+}
+
+func allProbes(cfg *config.Config) []probe {
+	selected := append([]probe{}, probes...)
+	seen := map[string]bool{}
+
+	for _, pr := range probes {
+		seen[pr.payload] = true
+	}
+
+	for _, payload := range cfg.NormalizedCustomPayloads() {
+		if seen[payload] {
+			continue
+		}
+
+		seen[payload] = true
+		selected = append(selected, probe{
+			label:     "Custom LFI payload",
+			payload:   payload,
+			signature: customSignature,
+		})
+	}
+
+	return selected
 }
 
 func inject(cfg *config.Config, client *http.Client, p recon.Param, payload string) *response {

--- a/internal/tools/v1/lfi/lfi_test.go
+++ b/internal/tools/v1/lfi/lfi_test.go
@@ -79,3 +79,37 @@ func TestRunNoFalsePositive(t *testing.T) {
 		t.Errorf("expected no findings, got %+v", findings)
 	}
 }
+
+func TestRunChecksCustomPayloads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		file := r.URL.Query().Get("file")
+
+		if file == "custom-passwd" {
+			fmt.Fprint(w, "root:x:0:0:root:/root:/bin/bash\n")
+			return
+		}
+
+		fmt.Fprint(w, "not found")
+	}))
+	defer srv.Close()
+
+	cfg := config.New(srv.URL)
+	cfg.Timeout = 5 * time.Second
+	cfg.CustomPayloads = []string{"custom-passwd"}
+
+	surface := recon.Surface{
+		Params: []recon.Param{
+			{Name: "file", Endpoint: srv.URL + "/read?file=home.html", Method: http.MethodGet},
+		},
+	}
+
+	findings := Run(&cfg, srv.Client(), &surface)
+
+	for _, f := range findings {
+		if strings.Contains(f.Evidence.Extracted, "custom-passwd") {
+			return
+		}
+	}
+
+	t.Errorf("expected custom LFI payload finding, got %+v", findings)
+}

--- a/internal/tools/v1/sqli/sqli.go
+++ b/internal/tools/v1/sqli/sqli.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/sayseven7/frameseven/internal/config"
@@ -43,6 +44,8 @@ var contexts = []injContext{
 	{"string", "' AND '1'='1", "' AND '1'='2", "' AND '1'='2' UNION SELECT ", "-- -"},
 	{"numeric", " AND 1=1", " AND 1=2", " AND 1=2 UNION SELECT ", "-- -"},
 }
+
+var sqlErrorSignature = regexp.MustCompile(`(?i)sql syntax|mysql|mariadb|postgresql|sqlite|sql server|odbc|jdbc|ora-\d+|syntax error|unclosed quotation|unterminated quoted string`)
 
 // dbProfile holds the DBMS-specific SQL used during extraction. wrap delimits a
 // scalar expression with markers using that DBMS's concatenation dialect.
@@ -162,7 +165,61 @@ func testParam(cfg *config.Config, client *http.Client, p recon.Param) []finding
 		return confirmed(cfg, client, p, orig, c, *truthy)
 	}
 
-	return nil
+	return testCustomPayloads(cfg, client, p, orig, *base)
+}
+
+func testCustomPayloads(cfg *config.Config, client *http.Client, p recon.Param, orig string, base response) []finding.Finding {
+	var findings []finding.Finding
+
+	for _, payload := range cfg.NormalizedCustomPayloads() {
+		injected := orig + payload
+		resp := request(cfg, client, p, injected)
+		if resp == nil {
+			continue
+		}
+
+		reason := customSQLiReason(base, *resp)
+		if reason == "" {
+			continue
+		}
+
+		findings = append(findings, finding.Finding{
+			Title:       "Custom SQL injection payload produced a suspicious response in parameter '" + p.Name + "'",
+			Module:      "sqli",
+			Severity:    finding.Medium,
+			OWASP:       "A03:2025 - Injection",
+			CWE:         "CWE-89",
+			CVSS:        6.5,
+			Description: "A caller-supplied SQL injection payload changed the response in a way that warrants manual verification.",
+			Evidence: finding.Evidence{
+				Request:   resp.dump,
+				Response:  trim(resp.body, 400),
+				Extracted: reason + " via " + injected,
+			},
+			NextSteps: []string{
+				"Manually verify whether the custom payload reached a SQL interpreter.",
+				"Use parameterized queries / prepared statements for this parameter.",
+			},
+		})
+	}
+
+	return findings
+}
+
+func customSQLiReason(base, resp response) string {
+	if resp.status >= 500 && resp.status != base.status {
+		return "server error"
+	}
+
+	if sqlErrorSignature.MatchString(resp.body) {
+		return "SQL error signature"
+	}
+
+	if similarity(base.body, resp.body) < 0.75 {
+		return "large response change"
+	}
+
+	return ""
 }
 
 func confirmed(cfg *config.Config, client *http.Client, p recon.Param, orig string, c injContext, detected response) []finding.Finding {

--- a/internal/tools/v1/sqli/sqli_run_test.go
+++ b/internal/tools/v1/sqli/sqli_run_test.go
@@ -73,3 +73,37 @@ func TestRunNoInjectionOnStableEndpoint(t *testing.T) {
 		t.Errorf("expected no findings on stable endpoint, got %+v", findings)
 	}
 }
+
+func TestRunChecksCustomPayloads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+
+		if strings.Contains(id, "custom-sqli") {
+			http.Error(w, "SQL syntax error near custom-sqli", http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprint(w, "regular item page")
+	}))
+	defer srv.Close()
+
+	cfg := config.New(srv.URL)
+	cfg.Timeout = 5 * time.Second
+	cfg.CustomPayloads = []string{"' custom-sqli"}
+
+	surface := recon.Surface{
+		Params: []recon.Param{
+			{Name: "id", Endpoint: srv.URL + "/item?id=2", Method: http.MethodGet},
+		},
+	}
+
+	findings := Run(&cfg, srv.Client(), &surface)
+
+	for _, f := range findings {
+		if strings.Contains(f.Title, "Custom SQL injection payload") {
+			return
+		}
+	}
+
+	t.Errorf("expected custom SQLi payload finding, got %+v", findings)
+}

--- a/internal/tools/v1/ssrf/ssrf.go
+++ b/internal/tools/v1/ssrf/ssrf.go
@@ -30,6 +30,7 @@ var probes = []probe{
 }
 
 var paramHint = regexp.MustCompile(`(?i)url|uri|link|src|dest|redirect|next|host|target|callback|img|image|load|fetch|domain|site|return|continue|feed|proxy`)
+var customSignature = regexp.MustCompile(`(?i)instance-id|ami-id|security-credentials|AccessKeyId|computeMetadata|/computeMetadata/v1/|project-id|azEnvironment|"compute"|vmId`)
 
 type response struct {
 	body string
@@ -80,7 +81,7 @@ func Run(cfg *config.Config, client *http.Client, surface *recon.Surface) []find
 func testParam(cfg *config.Config, client *http.Client, p recon.Param) []finding.Finding {
 	var findings []finding.Finding
 
-	for _, pr := range probes {
+	for _, pr := range allProbes(cfg) {
 		resp := inject(cfg, client, p, pr.payload)
 		if resp == nil || !pr.signature.MatchString(resp.body) {
 			continue
@@ -107,6 +108,30 @@ func testParam(cfg *config.Config, client *http.Client, p recon.Param) []finding
 	}
 
 	return findings
+}
+
+func allProbes(cfg *config.Config) []probe {
+	selected := append([]probe{}, probes...)
+	seen := map[string]bool{}
+
+	for _, pr := range probes {
+		seen[pr.payload] = true
+	}
+
+	for _, payload := range cfg.NormalizedCustomPayloads() {
+		if seen[payload] {
+			continue
+		}
+
+		seen[payload] = true
+		selected = append(selected, probe{
+			label:     "Custom SSRF payload",
+			payload:   payload,
+			signature: customSignature,
+		})
+	}
+
+	return selected
 }
 
 func inject(cfg *config.Config, client *http.Client, p recon.Param, payload string) *response {

--- a/internal/tools/v1/ssrf/ssrf_test.go
+++ b/internal/tools/v1/ssrf/ssrf_test.go
@@ -94,3 +94,37 @@ func TestRunSkipsNonURLParam(t *testing.T) {
 		}
 	}
 }
+
+func TestRunChecksCustomPayloads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		target := r.URL.Query().Get("url")
+
+		if target == "http://custom-metadata.local/latest" {
+			fmt.Fprint(w, "instance-id: i-custom\n")
+			return
+		}
+
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	cfg := config.New(srv.URL)
+	cfg.Timeout = 5 * time.Second
+	cfg.CustomPayloads = []string{"http://custom-metadata.local/latest"}
+
+	surface := recon.Surface{
+		Params: []recon.Param{
+			{Name: "url", Endpoint: srv.URL + "/fetch?url=http://test", Method: http.MethodGet},
+		},
+	}
+
+	findings := Run(&cfg, srv.Client(), &surface)
+
+	for _, f := range findings {
+		if strings.Contains(f.Evidence.Extracted, "http://custom-metadata.local/latest") {
+			return
+		}
+	}
+
+	t.Errorf("expected custom SSRF payload finding, got %+v", findings)
+}

--- a/internal/tools/v1/subdomain/subdomain.go
+++ b/internal/tools/v1/subdomain/subdomain.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/sayseven7/frameseven/internal/config"
@@ -147,6 +148,8 @@ var candidates = []string{
 	"vendor",
 }
 
+var candidateLabel = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{0,62}$`)
+
 // Run resolves common subdomain candidates and reports any that exist.
 func Run(cfg *config.Config, _ *http.Client, _ *recon.Surface) []finding.Finding {
 	base, err := url.Parse(cfg.Target)
@@ -160,7 +163,7 @@ func Run(cfg *config.Config, _ *http.Client, _ *recon.Surface) []finding.Finding
 	}
 
 	var found []string
-	for _, candidate := range candidates {
+	for _, candidate := range allCandidates(cfg) {
 		host := candidate + "." + root
 		addrs, err := net.LookupHost(host)
 		if err != nil || len(addrs) == 0 {
@@ -202,4 +205,30 @@ func rootDomain(host string) string {
 	}
 
 	return strings.Join(parts[len(parts)-2:], ".")
+}
+
+func allCandidates(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	var selected []string
+
+	for _, candidate := range candidates {
+		selected = appendCandidate(selected, seen, candidate)
+	}
+
+	for _, payload := range cfg.NormalizedCustomPayloads() {
+		selected = appendCandidate(selected, seen, strings.Trim(payload, "."))
+	}
+
+	return selected
+}
+
+func appendCandidate(candidates []string, seen map[string]bool, candidate string) []string {
+	candidate = strings.ToLower(strings.TrimSpace(candidate))
+	if candidate == "" || seen[candidate] || !candidateLabel.MatchString(candidate) {
+		return candidates
+	}
+
+	seen[candidate] = true
+
+	return append(candidates, candidate)
 }

--- a/internal/tools/v1/subdomain/subdomain_test.go
+++ b/internal/tools/v1/subdomain/subdomain_test.go
@@ -1,9 +1,34 @@
 package subdomain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sayseven7/frameseven/internal/config"
+)
 
 func TestCandidateListHasMinimumSize(t *testing.T) {
 	if len(candidates) < 100 {
 		t.Fatalf("candidates = %d, want at least 100", len(candidates))
+	}
+}
+
+func TestAllCandidatesAddsCustomLabels(t *testing.T) {
+	cfg := config.New("https://example.com")
+	cfg.CustomPayloads = []string{"custom-api", "https://bad.example", "custom-api"}
+
+	selected := allCandidates(&cfg)
+	var found bool
+	for _, candidate := range selected {
+		if candidate == "custom-api" {
+			found = true
+		}
+
+		if candidate == "https://bad.example" {
+			t.Fatalf("absolute URL should not be accepted as a subdomain label")
+		}
+	}
+
+	if !found {
+		t.Fatalf("custom-api was not added to candidates")
 	}
 }


### PR DESCRIPTION
## Summary
- add MCP custom_payloads input for Framework API v1 scanner and report tools
- apply custom payloads to SQLi, LFI, SSRF, content, access, and subdomain scans
- document payload limits, supported tools, and non-shell execution behavior

## Tests
- GOCACHE=/tmp/frameseven-go-cache go test -v ./...
- GOCACHE=/tmp/frameseven-go-cache go vet ./...